### PR TITLE
Updating admin screen styles to match WordPress

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,98 +1,97 @@
-/* Plugin title */
-.ocdi__title span {
-	line-height: 30px;
-}
+/* Overriding WordPress native styles */
 
-/* AJAX loader */
-.ocdi__ajax-loader {
-	font-size: 1.5em;
-	display: none;
-}
+	.ocdi h2 {
+		text-align: inherit;
+	}
 
-.ocdi__ajax-loader .spinner {
-	display: inline-block;
-	float: none;
-	visibility: visible;
-	margin-bottom: 6px;
-}
+	.ocdi h2:first-child,
+	.ocdi h3:first-child {
+		margin-top: 0;
+	}
 
-/* Plugin intro text */
-.ocdi__intro-text {
-	width: calc( 100% - 46px );
-	background-color: #f5fafd;
-	margin: 10px 0;
-	padding: 10px 20px;
-	color: #0C518F;
-	border: 1px solid #cae0f3;
-	border-left: 5px solid #cae0f3;
-	clear: both;
-}
+	.ocdi hr {
+		margin: 2.62em 0;
+	}
 
-.ocdi__intro-text ul {
-	padding-left: 40px;
-	list-style-type: square;
-}
+	.feature-section + hr {
+		margin-top: 0;
+	}
+
+	#wpbody select {
+		height: auto;
+		padding: .62em;
+		line-height: inherit;
+	}
+
+	.ocdi .notice {
+		display: block !important;
+	}
 
 /* Plugin elements */
-.ocdi__demo-import-preview-image-message {
-	font-style: italic;
-}
 
-#ocdi__demo-import-preview-image,
-#ocdi__demo-import-files {
-	max-width: 100%;
-}
+	.ocdi__demo-import-files {
+		width: 100%;
+	}
+
+	.ocdi__demo-import-preview-image-message {
+		font-style: italic;
+	}
+
+
+/* Plugin title */
+
+	.ocdi__title:before {
+		width: auto;
+		height: auto;
+		font-size: inherit;
+	}
+
+/* Plugin intro text */
+
+	.ocdi__intro-text ul {
+		padding: 0 4%;
+		list-style-type: square;
+	}
 
 /* Plugin multi select import and Plugin file upload containers */
-.ocdi__single-file-upload-container,
-.ocdi__multi-select-import {
-	width: calc( 100% - 46px );
-	background-color: #ffffff;
-	margin: 10px 0;
-	padding: 20px;
-	border: 1px solid #e5e5e5;
-	border-left: 5px solid #e5e5e5;
-}
 
-.ocdi__single-file-upload-container {
-	margin: 0;
-	margin-bottom: -1px;
-}
-
-.ocdi__single-file-upload-container span {
-	color: #999999;
-	float: right;
-}
-
-.ocdi__single-file-upload-container h3,
-.ocdi__multi-select-import h3 {
-	margin-top: 0;
-}
-
-.ocdi__single-file-upload-container h3 {
-	margin-bottom: .5em;
-}
-
-@media (min-width: 992px) {
-	.ocdi__single-file-upload-container,
-	.ocdi__multi-select-import {
-		width: 65%;
+	.ocdi__file-upload,
+	.ocdi__multi-select-import,
+	.ocdi__demo-import-notice:not(:empty) {
+		padding: 4%;
+		margin: 1.62em 0;
+		background-color: #fff;
+		border: 1px solid #e5e5e5;
 	}
-}
 
-@media (min-width: 1200px) {
-	.ocdi__single-file-upload-container,
-	.ocdi__multi-select-import {
-		width: 50%;
+	.ocdi__file-upload {
+		margin: 0;
+		margin-bottom: -1px;
 	}
-}
 
-/* WP info notice */
-.notice-info {
-	border-left-color: #58acfa;
-}
+	.ocdi__file-upload span {
+		font-size: .81em;
+		font-weight: 400;
+		opacity: .66;
+	}
 
-/* WP warning notice */
-.notice-warning {
-	border-left-color: #ed9232;
-}
+/* Plugin button */
+
+	.ocdi__button-container {
+		margin-top: 1.62em;
+	}
+
+/* AJAX loader */
+
+	.ocdi__ajax-loader {
+		font-size: 1.5em;
+		display: none;
+	}
+
+	.ocdi__ajax-loader .spinner {
+		display: inline-block;
+		float: none;
+		visibility: visible;
+		margin-bottom: 6px;
+	}
+	

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -47,12 +47,12 @@ jQuery( function ( $ ) {
 				$( '.js-ocdi-ajax-loader' ).hide();
 			}
 			else {
-				$( '.js-ocdi-ajax-response' ).append( '<div class="error  below-h2"><p>' + response + '</p></div>' );
+				$( '.js-ocdi-ajax-response' ).append( '<div class="notice notice-error is-dismissible"><p>' + response + '</p></div>' );
 				$( '.js-ocdi-ajax-loader' ).hide();
 			}
 		})
 		.fail( function( error ) {
-			$( '.js-ocdi-ajax-response' ).append( '<div class="error  below-h2"> Error: ' + error.statusText + ' (' + error.status + ')' + '</div>' );
+			$( '.js-ocdi-ajax-response' ).append( '<div class="notice notice-error is-dismissible"><p>Error: ' + error.statusText + ' (' + error.status + ')' + '</p></div>' );
 			$( '.js-ocdi-ajax-loader' ).hide();
 		});
 	}

--- a/inc/class-ocdi-main.php
+++ b/inc/class-ocdi-main.php
@@ -97,8 +97,9 @@ class PT_One_Click_Demo_Import {
 	public function display_plugin_page() {
 	?>
 
-	<div class="ocdi  wrap">
-		<h2 class="ocdi__title"><span class="dashicons  dashicons-download"></span><?php esc_html_e( 'One Click Demo Import', 'pt-ocdi' ); ?></h2>
+	<div class="ocdi wrap about-wrap">
+
+		<h1 class="ocdi__title dashicons-before dashicons-download"><?php esc_html_e( 'One Click Demo Import', 'pt-ocdi' ); ?></h1>
 
 		<?php
 
@@ -106,7 +107,7 @@ class PT_One_Click_Demo_Import {
 		if ( ini_get( 'safe_mode' ) ) {
 			printf(
 				esc_html__( '%sWarning: your server is using %sPHP safe mode%s. This means that you might experience server timeout errors.%s', 'pt-ocdi' ),
-				'<div class="notice  notice-warning"><p>',
+				'<div class="notice notice-warning is-dismissible"><p>',
 				'<strong>',
 				'</strong>',
 				'</p></div>'
@@ -117,54 +118,73 @@ class PT_One_Click_Demo_Import {
 		ob_start();
 		?>
 
+		<div class="ocdi__intro-notice notice notice-warning is-dismissible">
+			<p><?php esc_html_e( 'Before you begin, make sure all the required plugins are activated.', 'pt-ocdi' ); ?></p>
+		</div>
+
 		<div class="ocdi__intro-text">
-			<p>
-				<?php esc_html_e( 'Importing demo data (post, pages, images, theme settings, ...) is the easiest way to setup your theme. It will allow you to quickly edit everything instead of creating content from scratch. When you import the data, the following things might happen:', 'pt-ocdi' ); ?>
+
+			<p class="about-description">
+				<?php esc_html_e( 'Importing demo data (post, pages, images, theme settings, ...) is the easiest way to setup your theme.', 'pt-ocdi' ); ?>
+				<?php esc_html_e( 'It will allow you to quickly edit everything instead of creating content from scratch.', 'pt-ocdi' ); ?>
 			</p>
+
+			<hr>
+
+			<p><?php esc_html_e( 'When you import the data, the following things might happen:', 'pt-ocdi' ); ?></p>
 
 			<ul>
 				<li><?php esc_html_e( 'No existing posts, pages, categories, images, custom post types or any other data will be deleted or modified.', 'pt-ocdi' ); ?></li>
 				<li><?php esc_html_e( 'Posts, pages, images, widgets and menus will get imported.', 'pt-ocdi' ); ?></li>
 				<li><?php esc_html_e( 'Please click "Import Demo Data" button only once and wait, it can take a couple of minutes.', 'pt-ocdi' ); ?></li>
 			</ul>
-		</div>
 
-		<div class="ocdi__intro-text">
-			<p><?php esc_html_e( 'Before you begin, make sure all the required plugins are activated.', 'pt-ocdi' ); ?></p>
+			<hr>
+
 		</div>
 
 		<?php
-			$plugin_intro_text = ob_get_clean();
+		$plugin_intro_text = ob_get_clean();
 
-			// Display the plugin intro text (can be replaced with custom text through the filter below).
-			echo wp_kses_post( apply_filters( 'pt-ocdi/plugin_intro_text', $plugin_intro_text ) );
+		// Display the plugin intro text (can be replaced with custom text through the filter below).
+		echo wp_kses_post( apply_filters( 'pt-ocdi/plugin_intro_text', $plugin_intro_text ) );
 		?>
 
 
 		<?php if ( empty( $this->import_files ) ) : ?>
-			<div class="notice  notice-info  below-h2">
-				<p>
-					<?php esc_html_e( 'There are no predefined import files available in this theme. Please upload the import files manually!', 'pt-ocdi' ); ?>
-				</p>
+
+			<div class="notice notice-info is-dismissible">
+				<p><?php esc_html_e( 'There are no predefined import files available in this theme. Please upload the import files manually!', 'pt-ocdi' ); ?></p>
 			</div>
-			<div>
-				<div class="ocdi__single-file-upload-container">
+
+			<div class="ocdi__file-upload-container">
+
+				<h2><?php esc_html_e( 'Manual demo files upload', 'pt-ocdi' ); ?></h2>
+
+				<div class="ocdi__file-upload">
 					<h3><label for="content-file-upload"><?php esc_html_e( 'Choose a XML file for content import:', 'pt-ocdi' ); ?></label></h3>
 					<input id="ocdi__content-file-upload" type="file" name="content-file-upload">
 				</div>
-				<div class="ocdi__single-file-upload-container">
+
+				<div class="ocdi__file-upload">
 					<h3><label for="widget-file-upload"><?php esc_html_e( 'Choose a WIE or JSON file for widget import:', 'pt-ocdi' ); ?></label> <span><?php esc_html_e( '(*optional)', 'pt-ocdi' ); ?></span></h3>
 					<input id="ocdi__widget-file-upload" type="file" name="widget-file-upload">
 				</div>
-				<div class="ocdi__single-file-upload-container">
+
+				<div class="ocdi__file-upload">
 					<h3><label for="customizer-file-upload"><?php esc_html_e( 'Choose a DAT file for customizer import:', 'pt-ocdi' ); ?></label> <span><?php esc_html_e( '(*optional)', 'pt-ocdi' ); ?></span></h3>
 					<input id="ocdi__customizer-file-upload" type="file" name="customizer-file-upload">
 				</div>
+
 			</div>
+
 		<?php elseif ( 1 < count( $this->import_files ) ) : ?>
+
 			<div class="ocdi__multi-select-import">
-				<h3><?php esc_html_e( 'Choose which demo you want to import:', 'pt-ocdi' ); ?></h3>
-				<select id="ocdi__demo-import-files">
+
+				<h2><?php esc_html_e( 'Choose which demo you want to import:', 'pt-ocdi' ); ?></h2>
+
+				<select id="ocdi__demo-import-files" class="ocdi__demo-import-files">
 					<?php foreach ( $this->import_files as $index => $import_file ) : ?>
 						<option value="<?php echo esc_attr( $index ); ?>">
 							<?php echo esc_html( $import_file['import_file_name'] ); ?>
@@ -184,39 +204,44 @@ class PT_One_Click_Demo_Import {
 
 				if ( $preview_image_is_defined ) :
 				?>
-				<div>
+
+				<div class="ocdi__demo-import-preview-container">
+
 					<p><?php esc_html_e( 'Import preview:', 'pt-ocdi' ); ?></p>
-					<p class="ocdi__demo-import-preview-image-message  js-ocdi-preview-image-message">
-						<?php
+
+					<p class="ocdi__demo-import-preview-image-message js-ocdi-preview-image-message"><?php
 						if ( ! isset( $this->import_files[0]['import_preview_image_url'] ) ) {
 							esc_html_e( 'No preview image defined for this import.', 'pt-ocdi' );
 						}
 						// Leave the img tag below and the p tag above available for later changes via JS.
-						?>
-					</p>
+					?></p>
+
 					<img id="ocdi__demo-import-preview-image" class="js-ocdi-preview-image" src="<?php echo ! empty( $this->import_files[0]['import_preview_image_url'] ) ? esc_url( $this->import_files[0]['import_preview_image_url'] ) : ''; ?>">
+
 				</div>
+
 				<?php endif; ?>
+
 			</div>
+
 		<?php endif; ?>
 
-		<div class="ocdi__demo-import-notice  js-ocdi-demo-import-notice">
-			<?php
+		<div class="ocdi__demo-import-notice js-ocdi-demo-import-notice"><?php
 			if ( is_array( $this->import_files ) && ! empty( $this->import_files[0]['import_notice'] ) ) {
 				echo wp_kses_post( $this->import_files[0]['import_notice'] );
 			}
-			?>
-		</div>
+		?></div>
 
-		<p>
+		<p class="ocdi__button-container">
 			<button class="ocdi__button button button-hero button-primary js-ocdi-import-data"><?php esc_html_e( 'Import Demo Data', 'pt-ocdi' ); ?></button>
 		</p>
 
-		<p class="ocdi__ajax-loader  js-ocdi-ajax-loader">
+		<p class="ocdi__ajax-loader js-ocdi-ajax-loader">
 			<span class="spinner"></span> <?php esc_html_e( 'Importing, please wait!', 'pt-ocdi' ); ?>
 		</p>
 
-		<div class="ocdi__response  js-ocdi-ajax-response"></div>
+		<div class="ocdi__response js-ocdi-ajax-response"></div>
+
 	</div>
 
 	<?php


### PR DESCRIPTION
## CSS styles

As I haven't got the access to source preprocessor files, I've edited the `assets/css/main.css` file manually. Please update your preprocessor files accordingly if necessary.

## Here is how the PR looks like

### Example of multiple predefined demo imports, that a user can choose from:

![Example of multiple predefined demo imports, that a user can choose from.](https://cloud.githubusercontent.com/assets/2456735/17139743/001c0a76-5346-11e6-8099-f2ed5aa2f05f.jpg)

### How the import page looks like, when only one demo import is predefined:

![How the import page looks like, when only one demo import is predefined.](https://cloud.githubusercontent.com/assets/2456735/17139744/001cceca-5346-11e6-8415-622ecff9ccbb.jpg)

### Example of how the import page looks like, when no demo imports are predefined a.k.a manual import:

![Example of how the import page looks like, when no demo imports are predefined a.k.a manual import.](https://cloud.githubusercontent.com/assets/2456735/17139742/001ad0b6-5346-11e6-9866-0b2d89f581db.jpg)