### PR TITLE
Added `pt-ocdi/pre_download_import_files` filter

### DIFF
--- a/inc/Helpers.php
+++ b/inc/Helpers.php
@@ -67,6 +67,8 @@ class Helpers {
 		);
 		$downloader = new Downloader();
 
+		$import_file_info = apply_filters('pt-ocdi/pre_download_import_files', $import_file_info);
+
 		// ----- Set content file path -----
 		// Check if 'import_file_url' is not defined. That would mean a local file.
 		if ( empty( $import_file_info['import_file_url'] ) ) {

--- a/readme.md
+++ b/readme.md
@@ -339,6 +339,37 @@ You can disable the branding notice with a WP filter. All you need to do is add 
 
 and the notice will not be displayed.
 
+### How can I pass Amazon S3 presigned URL's (temporary links) as external files ? ###
+
+If you want to host your import content files on Amazon S3, but you want them to be publicly available, rather through an own API as presigned URL's (which expires) you can use the filter `pt-ocdi/pre_download_import_files` in which you can pass your own URL's, for example:
+
+```
+add_filter( 'pt-ocdi/pre_download_import_files', function( $import_file_info ){
+
+	// In this example `get_my_custom_urls` is supposedly making a `wp_remote_get` request, getting the urls from an API server where you're creating the presigned urls, [example here](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-presigned-url.html).
+	// This request should return an array containing all the 3 links - `import_file_url`, `import_widget_file_url`, `import_customizer_file_url`
+	$request = get_my_custom_urls( $import_file_info );
+
+	if ( !is_wp_error( $request ) )
+	{
+		if ( isset($request['data']) && is_array($request['data']) )
+		{
+			if( isset($request['data']['import_file_url']) && $import_file_url = $request['data']['import_file_url'] ){
+				$import_file_info['import_file_url'] = $import_file_url;
+			}
+			if( isset($request['data']['import_widget_file_url']) && $import_widget_file_url = $request['data']['import_widget_file_url'] ){
+				$import_file_info['import_widget_file_url'] = $import_widget_file_url;
+			}
+			if( isset($request['data']['import_customizer_file_url']) && $import_customizer_file_url = $request['data']['import_customizer_file_url'] ){
+				$import_file_info['import_customizer_file_url'] = $import_customizer_file_url;
+			}
+		}
+	}
+
+	return $import_file_info;
+
+} );
+```
 
 ### I can't activate the plugin, because of a fatal error, what can I do? ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -339,6 +339,37 @@ You can disable the branding notice with a WP filter. All you need to do is add 
 
 and the notice will not be displayed.
 
+= How can I pass Amazon S3 presigned URL's (temporary links) as external files ? =
+
+If you want to host your import content files on Amazon S3, but you want them to be publicly available, rather through an own API as presigned URL's (which expires) you can use the filter `pt-ocdi/pre_download_import_files` in which you can pass your own URL's, for example:
+
+```
+add_filter( 'pt-ocdi/pre_download_import_files', function( $import_file_info ){
+
+	// In this example `get_my_custom_urls` is supposedly making a `wp_remote_get` request, getting the urls from an API server where you're creating the presigned urls, [example here](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-presigned-url.html).
+	// This request should return an array containing all the 3 links - `import_file_url`, `import_widget_file_url`, `import_customizer_file_url`
+	$request = get_my_custom_urls( $import_file_info );
+
+	if ( !is_wp_error( $request ) )
+	{
+		if ( isset($request['data']) && is_array($request['data']) )
+		{
+			if( isset($request['data']['import_file_url']) && $import_file_url = $request['data']['import_file_url'] ){
+				$import_file_info['import_file_url'] = $import_file_url;
+			}
+			if( isset($request['data']['import_widget_file_url']) && $import_widget_file_url = $request['data']['import_widget_file_url'] ){
+				$import_file_info['import_widget_file_url'] = $import_widget_file_url;
+			}
+			if( isset($request['data']['import_customizer_file_url']) && $import_customizer_file_url = $request['data']['import_customizer_file_url'] ){
+				$import_file_info['import_customizer_file_url'] = $import_customizer_file_url;
+			}
+		}
+	}
+
+	return $import_file_info;
+
+} );
+```
 
 = I can't activate the plugin, because of a fatal error, what can I do? =
 


### PR DESCRIPTION
Added this filter to download packages before running the actual downloads.

I'm trying to pass AWS S3 presigned download url's with expiration time, on `import_file_url`, `import_widget_file_url` and `import_customizer_file_url` but because they're temporary, this would be applicable only if the expiring URL request is made when the dialog is confirmed ( clear decision that user wants to import the demo ).

If you're familiar with WP's `upgrader_package_options` filter, it would basically mean the same, before running the WP updates, plugin or theme options can be filtered and their download links can be changed.