### PR TITLE
Add two hooks to plugin-page.php

### DIFF
--- a/views/plugin-page.php
+++ b/views/plugin-page.php
@@ -14,9 +14,9 @@ if ( ! empty( $this->import_files ) && isset( $_GET['import-mode'] ) && 'manual'
 }
 
 /**
- * Hook for adding the custom admin page header
+ * Hook for adding the custom plugin page header
  */
-do_action('ocdi_admin_page_header');
+do_action( 'pt-ocdi/plugin_page_header' );
 ?>
 
 <div class="ocdi  wrap  about-wrap">
@@ -206,5 +206,4 @@ do_action('ocdi_admin_page_header');
 /**
  * Hook for adding the custom admin page footer
  */
-do_action('ocdi_admin_page_footer');
-?>
+do_action( 'pt-ocdi/plugin_page_footer' );

--- a/views/plugin-page.php
+++ b/views/plugin-page.php
@@ -13,6 +13,10 @@ if ( ! empty( $this->import_files ) && isset( $_GET['import-mode'] ) && 'manual'
 	$predefined_themes = array();
 }
 
+/**
+ * Hook for adding the custom admin page header
+ */
+do_action('ocdi_admin_page_header');
 ?>
 
 <div class="ocdi  wrap  about-wrap">
@@ -197,3 +201,10 @@ if ( ! empty( $this->import_files ) && isset( $_GET['import-mode'] ) && 'manual'
 
 	<div class="ocdi__response  js-ocdi-ajax-response"></div>
 </div>
+
+<?php
+/**
+ * Hook for adding the custom admin page footer
+ */
+do_action('ocdi_admin_page_footer');
+?>


### PR DESCRIPTION
I have added two hooks for adding admin page header and footer in view/plugin-page.php
In some situations, the theme authors want to integrate the demo import page to their own admin page or add their own admin top menu to the demo import page, so they can use add_action() to do that easily without making a wrapper plugin to include this plugin again.